### PR TITLE
Rvn no proto

### DIFF
--- a/ColoMechDefs/mech/mechdef_raven_RVN-3M.json
+++ b/ColoMechDefs/mech/mechdef_raven_RVN-3M.json
@@ -10,7 +10,6 @@
 			"unit_littlefriend",
 			"unit_bracket_med",
 			"unit_generic",
-			"unit_prototype",
 			"unit_littlefriend",
 			"unit_predator",
 			"comstar",

--- a/ColoMechDefs/mech/mechdef_raven_RVN-4L.json
+++ b/ColoMechDefs/mech/mechdef_raven_RVN-4L.json
@@ -10,8 +10,6 @@
 			"unit_bracket_low",
 			"unit_advanced",
 			"unit_littlefriend",
-			"unit_legendary",
-			"unit_prototype",
 			"unit_predator",
 			"unit_bracket_med",
 			"unit_jumpOK",


### PR DESCRIPTION
Master Unit List labels RVN-3M and RVN-4L as a Standard variant and not experimental, prototype or legendary.

http://www.masterunitlist.info/Unit/Details/2664/